### PR TITLE
New Rule: drizzle/no-logical-operators-in-where

### DIFF
--- a/src/avoid-logical-operators-in-where.ts
+++ b/src/avoid-logical-operators-in-where.ts
@@ -1,0 +1,45 @@
+import type { TSESLint } from "@typescript-eslint/utils";
+
+type MessageIds = "avoidLogicalOperatorsInWhere";
+
+const logicalOperatorsRule: TSESLint.RuleModule<MessageIds> = {
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "TODO",
+      url: "https://github.com/drizzle-team/eslint-plugin-drizzle",
+    },
+    fixable: "code",
+    messages: {
+      avoidLogicalOperatorsInWhere: "TODO",
+    },
+    schema: [],
+  },
+  create(context) {
+    function fail(node: any) {
+      context.report({
+        node,
+        messageId: "avoidLogicalOperatorsInWhere",
+      });
+    }
+    return {
+      CallExpression: (node) => {
+        if (node.callee.type === "MemberExpression") {
+          if (node.callee.property.type === "Identifier") {
+            if (node.callee.property.name === "where") {
+              if (node.arguments[0]?.type === "LogicalExpression") {
+                fail(node);
+              }
+              if (node.arguments[0]?.type === "BinaryExpression") {
+                fail(node);
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+};
+
+export default logicalOperatorsRule;

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -10,5 +10,6 @@ export default {
   rules: {
     "drizzle/enforce-delete-with-where": "error",
     "drizzle/enforce-update-with-where": "error",
+    "drizzle/no-logical-operators-in-where": "error",
   },
 };

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -10,5 +10,6 @@ export default {
   rules: {
     "drizzle/enforce-delete-with-where": "error",
     "drizzle/enforce-update-with-where": "error",
+    "drizzle/no-logical-operators-in-where": "error",
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 import deleteRule from "./enforce-delete-with-where";
 import updateRule from "./enforce-update-with-where";
+import logicalOperatorsRule from "./no-logical-operators-in-where";
 import { name, version } from "../package.json";
 import all from "./configs/all";
 import recommended from "./configs/recommended";
@@ -8,6 +9,7 @@ import recommended from "./configs/recommended";
 export const rules = {
   "enforce-delete-with-where": deleteRule,
   "enforce-update-with-where": updateRule,
+  "no-logical-operators-in-where": logicalOperatorsRule,
 } satisfies Record<string, TSESLint.RuleModule<string, Array<unknown>>>;
 
 export const configs = { all, recommended };

--- a/src/no-logical-operators-in-where.ts
+++ b/src/no-logical-operators-in-where.ts
@@ -1,6 +1,6 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 
-type MessageIds = "avoidLogicalOperatorsInWhere";
+type MessageIds = "noLogicalOperatorsInWhere";
 
 const logicalOperatorsRule: TSESLint.RuleModule<MessageIds> = {
   defaultOptions: [],
@@ -12,15 +12,15 @@ const logicalOperatorsRule: TSESLint.RuleModule<MessageIds> = {
     },
     fixable: "code",
     messages: {
-      avoidLogicalOperatorsInWhere: "TODO",
+      noLogicalOperatorsInWhere: "TODO",
     },
     schema: [],
   },
   create(context) {
-    function fail(node: any) {
+    function error(node: any) {
       context.report({
         node,
-        messageId: "avoidLogicalOperatorsInWhere",
+        messageId: "noLogicalOperatorsInWhere",
       });
     }
     return {
@@ -29,10 +29,10 @@ const logicalOperatorsRule: TSESLint.RuleModule<MessageIds> = {
           if (node.callee.property.type === "Identifier") {
             if (node.callee.property.name === "where") {
               if (node.arguments[0]?.type === "LogicalExpression") {
-                fail(node);
+                error(node);
               }
               if (node.arguments[0]?.type === "BinaryExpression") {
-                fail(node);
+                error(node);
               }
             }
           }

--- a/src/no-logical-operators-in-where.ts
+++ b/src/no-logical-operators-in-where.ts
@@ -7,12 +7,14 @@ const logicalOperatorsRule: TSESLint.RuleModule<MessageIds> = {
   meta: {
     type: "problem",
     docs: {
-      description: "TODO",
-      url: "https://github.com/drizzle-team/eslint-plugin-drizzle",
+      description:
+        "Enforce that the caller use functions provided by Drizzle (eg: `and`, `or`) instead of logical operators (eg: `&&`, `||`, `>`, `==`)",
+      url: "https://orm.drizzle.team/docs/operators",
     },
     fixable: "code",
     messages: {
-      noLogicalOperatorsInWhere: "TODO",
+      noLogicalOperatorsInWhere:
+        "Avoid using plain logical operators in `where` clause, please see https://orm.drizzle.team/docs/operators",
     },
     schema: [],
   },

--- a/tests/logicalExpressionInWhere.test.ts
+++ b/tests/logicalExpressionInWhere.test.ts
@@ -1,0 +1,67 @@
+// @ts-ignore
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import myRule from "../src/avoid-logical-operators-in-where";
+
+const parserResolver = require.resolve("@typescript-eslint/parser");
+
+const ruleTester = new RuleTester({
+  parser: parserResolver,
+});
+
+ruleTester.run("my-rule", myRule, {
+  valid: [
+    "const a = db.delete({}).where({});",
+    "delete db.something",
+    `dataSource
+      .delete()
+      .where()`,
+    "someFunction(a && b)",
+    "object.method(c || d)",
+    "where.do(x | b)",
+    "foo(where && other)",
+  ],
+  invalid: [
+    {
+      code: "db.delete.where({} && {})",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.delete.where({} || {})",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.delete.where({} & {})",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.delete.where({} | {})",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+
+    {
+      code: "db.select().from(t_somehting).where({} && {})",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.select().from(t_other_thing).where({} || {})",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.select().from(t_other_thing).where({} & {})",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.select().from(t_stored_stuff).where({} | {})",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "ctx.select().from(t_foo).where(eq(t_foo.id, id) && eq(t_foo.date, date))",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "ctx.select().from(t_foo).innerJoin(t_bar, eq(t_foo.id, t_bar.foo_id)).where(eq(t_foo.id, id) && eq(t_foo.date, date))",
+      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+    },
+  ],
+});

--- a/tests/logicalExpressionInWhere.test.ts
+++ b/tests/logicalExpressionInWhere.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { RuleTester } from "@typescript-eslint/rule-tester";
 
-import myRule from "../src/avoid-logical-operators-in-where";
+import myRule from "../src/no-logical-operators-in-where";
 
 const parserResolver = require.resolve("@typescript-eslint/parser");
 
@@ -24,44 +24,44 @@ ruleTester.run("my-rule", myRule, {
   invalid: [
     {
       code: "db.delete.where({} && {})",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
     {
       code: "db.delete.where({} || {})",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
     {
       code: "db.delete.where({} & {})",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
     {
       code: "db.delete.where({} | {})",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
 
     {
       code: "db.select().from(t_somehting).where({} && {})",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
     {
       code: "db.select().from(t_other_thing).where({} || {})",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
     {
       code: "db.select().from(t_other_thing).where({} & {})",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
     {
       code: "db.select().from(t_stored_stuff).where({} | {})",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
     {
       code: "ctx.select().from(t_foo).where(eq(t_foo.id, id) && eq(t_foo.date, date))",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
     {
       code: "ctx.select().from(t_foo).innerJoin(t_bar, eq(t_foo.id, t_bar.foo_id)).where(eq(t_foo.id, id) && eq(t_foo.date, date))",
-      errors: [{ messageId: "avoidLogicalOperatorsInWhere" }],
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
   ],
 });

--- a/tests/logicalExpressionInWhere.test.ts
+++ b/tests/logicalExpressionInWhere.test.ts
@@ -51,6 +51,27 @@ ruleTester.run("my-rule", myRule, {
       code: "db.select().from(t_other_thing).where({} & {})",
       errors: [{ messageId: "noLogicalOperatorsInWhere" }],
     },
+
+    {
+      code: "db.select().from(t_other_thing).where(a > b)",
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.select().from(t_other_thing).where(a < b)",
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.select().from(t_other_thing).where(a == b)",
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.select().from(t_other_thing).where(a >= b)",
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
+    },
+    {
+      code: "db.select().from(t_other_thing).where(a <= b)",
+      errors: [{ messageId: "noLogicalOperatorsInWhere" }],
+    },
     {
       code: "db.select().from(t_stored_stuff).where({} | {})",
       errors: [{ messageId: "noLogicalOperatorsInWhere" }],


### PR DESCRIPTION
Hi, the last weeks I've seen gen AI tools like [GitHub Copilot](https://azure.microsoft.com/es-mx/products/github/Copilot) and [Supermaven](https://supermaven.com/) autocomplete code like this:
```javascript
db.select().from(t_user).where(eq(t_user.id, 12) && eq(t_user.status, 'active'))  // wrong!
```

This is  **just wrong**, the correct code is:

```javascript
db.select().from(t_user).where(and(eq(t_user.id, 12), eq(t_user.status, 'active'))) // correct :)
```

The big problem is that is mistake can be trigger using a typescript error, so it can easily slip into production code if you are not carefully enough. Furthermore, this issue is extended to all type of logical and binary operators (`==`, `>`, `&`, `||`, etc).

I see that this is a problem  we can only catch with static analysis, therefore I extended this plugin to include a new rule to address this pitfall.
